### PR TITLE
修复JDBC例程中的Delete方法

### DIFF
--- a/springboot-jdbc/src/main/java/com/forezp/dao/impl/AccountDaoImpl.java
+++ b/springboot-jdbc/src/main/java/com/forezp/dao/impl/AccountDaoImpl.java
@@ -32,7 +32,7 @@ public class AccountDaoImpl implements IAccountDAO {
 
     @Override
     public int delete(int id) {
-        return jdbcTemplate.update("DELETE from TABLE account where id=?",id);
+        return jdbcTemplate.update("DELETE from account where id=?",id);
     }
 
     @Override

--- a/springboot-jdbc/src/main/java/com/forezp/web/AccountController.java
+++ b/springboot-jdbc/src/main/java/com/forezp/web/AccountController.java
@@ -58,4 +58,16 @@ public class AccountController {
 
     }
 
+    @RequestMapping(value="/{id}",method=RequestMethod.DELETE)
+    public String deleteAccount(@PathVariable("id")int id){
+        Account account = new Account();
+        account.setId(id);
+        int t = accountService.delete(account.getId());
+        if(t==1){
+            return account.toString();
+        }else{
+            return  "delete failed";
+        }
+    }
+
 }


### PR DESCRIPTION
- 删除SQL命令中多余的“TABLE"字符(否则报错：
	`DELETE from TABLE account where id=	Error Code: 1064. You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'TABLE account where id=' at line 1	0.000 sec）`
- 补全 `Controller` 中的 DELETE 方法
